### PR TITLE
adapt setting of env var to github action

### DIFF
--- a/.github/workflows/verify-and-publish.yml
+++ b/.github/workflows/verify-and-publish.yml
@@ -57,6 +57,7 @@ jobs:
           exitOnceUploaded: true
           onlyChanged: true
           workingDir: web-components
+          buildScriptName: 'build-storybook:chromatic'
           autoAcceptChanges: main
           zip: true
 

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -25,11 +25,11 @@
     "storybook": "storybook dev -p 6006 --no-open",
     "prebuild-storybook": "npm run build",
     "build-storybook": "storybook build",
+    "build-storybook:chromatic": "VITE_IS_CHROMATIC=true storybook build",
     "test": "vitest run --reporter=verbose --reporter=junit --coverage",
     "test:watch": "vitest",
     "design-tokens:generate": "node ./tokens/style-dictionary.cjs",
-    "icons:generate": "node src/components/icon/generate-icon-types.js",
-    "chromatic": "VITE_IS_CHROMATIC=true chromatic"
+    "icons:generate": "node src/components/icon/generate-icon-types.js"
   },
   "dependencies": {
     "@floating-ui/dom": "1.6.3",


### PR DESCRIPTION
Apparently the github action we use, does not call the script "chromatic" but "build-storybook" so passing the env var has to happen with a specific script set in the action